### PR TITLE
Use new SphereIcosahedral class in icosahedron laplacian calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@
 
 This is a PyTorch implementation of DeepSphere.
 
-- [Resources](#resources)
-- [Data](#data)
-- [Quick Start](#quick-start)
-- [Mathematical Background](#mathematical-background)
-- [U-Net](#unet)
-- [Temporality](#communication)
-- [Metric](#metric)
-- [Tools](#tools)
-- [License & co](#license--co)
+- [DeepSphere: a graph-based spherical CNN](#deepsphere-a-graph-based-spherical-cnn)
+  - [Resources](#resources)
+  - [Data](#data)
+  - [Quick Start](#quick-start)
+  - [Mathematical Background](#mathematical-background)
+  - [Unet](#unet)
+  - [Temporality](#temporality)
+  - [Metric](#metric)
+  - [Tools](#tools)
+  - [License & co](#license--co)
 
 ## Resources
 
@@ -57,7 +58,7 @@ Our recommendation for a linux based machine is:
 ```
 conda create --name deepsphere python=3.7
 
-source activate deepsphere
+conda activate deepsphere
 
 pip install git+https://github.com/epfl-lts2/pygsp.git@39a0665f637191152605911cf209fc16a36e5ae9#egg=PyGSP
 

--- a/deepsphere/models/spherical_unet/decoder.py
+++ b/deepsphere/models/spherical_unet/decoder.py
@@ -116,6 +116,8 @@ class Decoder(nn.Module):
         x = self.dec_l3(x, x_enc3)
         x = self.dec_l4(x, x_enc4)
         x = self.dec_l5(x)
+
         if not self.training:
             x = self.softmax(x)
+            
         return x

--- a/deepsphere/models/spherical_unet/decoder.py
+++ b/deepsphere/models/spherical_unet/decoder.py
@@ -116,8 +116,6 @@ class Decoder(nn.Module):
         x = self.dec_l3(x, x_enc3)
         x = self.dec_l4(x, x_enc4)
         x = self.dec_l5(x)
-
         if not self.training:
             x = self.softmax(x)
-            
         return x

--- a/deepsphere/utils/laplacian_funcs.py
+++ b/deepsphere/utils/laplacian_funcs.py
@@ -3,9 +3,9 @@
 
 import numpy as np
 import torch
-from pygsp.graphs.nngraphs.spherehealpix import SphereHealpix
-from pygsp.graphs.nngraphs.sphereicosahedron import SphereIcosahedron
-from pygsp.graphs.sphereequiangular import SphereEquiangular
+from pygsp.graphs import SphereHealpix
+from pygsp.graphs import SphereIcosahedral
+from pygsp.graphs import SphereEquiangular
 from scipy import sparse
 from scipy.sparse import coo_matrix
 
@@ -79,7 +79,7 @@ def get_icosahedron_laplacians(nodes, depth, laplacian_type):
     for _ in range(depth):
         nodes = icosahedron_nodes_calculator(order)
         order_initial = icosahedron_order_calculator(nodes)
-        G = SphereIcosahedron(level=int(order_initial))
+        G = SphereIcosahedral(subdivisions=2**int(order_initial))
         G.compute_laplacian(laplacian_type)
         laplacian = prepare_laplacian(G.L)
         laps.append(laplacian)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyyaml==5.2
 jupyter==1.0.0
 pytorch-ignite==0.2.1
 pillow==6.2.2
+trimesh==3.9.35


### PR DESCRIPTION
resolves #8

Changes:

- README setup instruction to use new style conda environment activation, TOC update
- new import paths
- change to SphereIcosahedral instantiation to use new subdivisions arg
- added trimesh package to requirements

It looks like there may still be an issue with the SphereEquiangular constructor but I'll leave that for someone who knows more about that class :).